### PR TITLE
Add 'theakshaypant' to members and collaborators

### DIFF
--- a/org/org.yaml
+++ b/org/org.yaml
@@ -392,6 +392,8 @@ orgs:
         members:
         - zakisk
         - sm43
+        - zakisk
+        - theakshaypant
         privacy: closed
         repos:
           pipelines-as-code: maintain
@@ -738,6 +740,7 @@ orgs:
         - sm43
         - infernus01
         - zakisk
+        - theakshaypant
         privacy: closed
         repos:
           pipelines-as-code: read


### PR DESCRIPTION
* Added `theakshaypant` to the members list of two organization teams to grant access to relevant repositories.
akshay is a core contributor on pac 